### PR TITLE
Move Github action for keyword to the root

### DIFF
--- a/.github/workflows/avh.yml
+++ b/.github/workflows/avh.yml
@@ -1,0 +1,79 @@
+# This is a basic workflow to help you get started with Actions on CMSIS projects
+
+name: ATS keyword workflow
+
+# Controls when the action will run.
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  push:
+    branches: [ main, test-actions ]
+  pull_request:
+    branches: [ main, test-actions ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "ci_build_and_test_ats_keyword"
+  ci_build_and_test_ats_keyword:
+    # The type of runner that the job will run on
+    #runs-on: ubuntu-latest
+    runs-on: self-hosted
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - uses: actions/checkout@v2
+
+      # Cleanup of previous environment
+      - name: Cleanup of self hosted runner environment
+        run : |
+          rm -rf build
+          rm -rf venv
+          rm -rf lib/*
+          git clean -xfd
+          git reset --hard
+
+      # Boostrap the environment
+      - name: Bootstrap environment
+        run : |
+          ./bootstrap.sh
+
+      # Setup python environment
+      - name: Setup Python environment
+        run: |
+          python3 -m venv venv
+          source venv/bin/activate
+          pip3 install click imgtool pytest
+
+      # Execute CMSIS Build command to build the executable for a Cortex-M55 using Arm Compiler
+      - name: Build kws application
+        run : |
+          source venv/bin/activate
+          ./build.sh kws
+
+      # Execute CMSIS Build command to build the executable for a Cortex-M55 using Arm Compiler
+      - name: Build blinky application
+        run : |
+          source venv/bin/activate
+          ./build.sh blinky
+
+      - name: Archive artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: binaries
+          path: |
+            ${{ github.workspace }}/build/bootloader/bl2.axf
+            ${{ github.workspace }}/build/secure_partition/tfm_s.axf
+            ${{ github.workspace }}/build/blinky/tfm_ns.axf
+            ${{ github.workspace }}/build/kws/tfm_ns.axf
+
+      - name: Run blinky integration test
+        run : |
+          source venv/bin/activate
+          pytest -s blinky/tests
+
+      - name: Run kws integration test
+        run : |
+          source venv/bin/activate
+          pytest -s kws/tests


### PR DESCRIPTION
.github folder will be removed from the keyword example in the next release. The folder should be present in this repository, in the root and enable workflow for each example.

Easier to maintain, all in one place.