### PR TITLE
submodules: move the file to the root

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ats-keyword-lib/VHT"]
+	path = examples/ats-keyword/lib/VHT
+	url = https://github.com/ARM-software/VHT


### PR DESCRIPTION
The git submodules do not support being in the subtree, we experienced issues:
`fatal: No url found for submodule path 'lib/VHT' in .gitmodules`

I copy and fix the paths in the submodules to the root. We do not need to edit
submodules in the tree (no need to edit examples in this case, only the root file
is being used. This is temporary fix). The best will be to move away from
submodules and let CMake fetch the repo, works much easier with workflow like
in this project (having multiple repositories under one roof).